### PR TITLE
Change behavior of escape

### DIFF
--- a/doc/readline.txt
+++ b/doc/readline.txt
@@ -122,19 +122,24 @@ CTRL-X CTRL-E		Open command-line window.  See |cmdline| for more
 META KEY					*readline-meta*
 
 This plugin uses <Esc> for META mappings.  This means that in order to trigger
-the <M-Key> mapping, you should use <Esc><Key>.  Previously the commands were
-also accessible by using the ALT or META modifier, but that caused problems
-where some accented characters like ä would be interpreted as meta-key
-commands and trigger mappings.
+the <M-Key> mapping, the input <Esc><Key> should be received.  The reason for
+this is that Vim cannot distinguish some accented characters like ä from
+META-keycodes.  Most terminal emulators can be configured to send <Esc><Key>
+when <Key> is pressed and the ALT-modifier is held.  This is highly
+recommended for the plugin to work properly.
 
-If you want to access the mappings using the ALT or META modifier, you can
-enable them using `let g:readline_meta = 1` in your vimrc.  This option is
-ignored if using Nvim which does not have problems distinguishing the affected
-key-chords from special characters.
+In some situations (like in the graphical Vim GUI) that is not possible.  If
+you want to access the mappings using the ALT or META modifier in these
+situations, you can enable it by using `let g:readline_meta = 1` in your
+vimrc.  This might interfere with your ability to insert characters like ä on
+the command-line.
 
-Note that most terminals can be configured to send <Esc><Key> when <Key> is
-pressed and the ALT modifier is held.  This is highly recommended, and
-required for META key-chord mappings to work in Nvim.
+By default it is not possible to trigger mappings by pressing <Esc> followed
+by another key sequentially.  This is because all the keys in the mapping have
+to be received simultaneously.  If you want to be able to trigger mappings by
+pressing <Esc> manually, you can enable it by using `let g:readline_esc = 1`
+in your vimrc.  When this is enabled it is no longer possible to quit the
+command-line using <Esc>.
 
 ==============================================================================
 INSERT MODE					*readline-insert*

--- a/plugin/readline.vim
+++ b/plugin/readline.vim
@@ -2,7 +2,7 @@
 " File:         plugin/readline.vim
 " Description:  Readline-style mappings for command-line mode
 " Author:       Elias Astrom <github.com/ryvnf>
-" Last Change:  2019 May 10
+" Last Change:  2019 June 9
 " License:      The VIM LICENSE
 " ============================================================================
 
@@ -14,12 +14,6 @@ let g:loaded_readline = 1
 "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 " mappings
 "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-" avoid quitting the cmdline on invalid mapping
-cnoremap <esc> <nop>
-
-" avoid inserting ^X on invalid mapping
-cnoremap <c-x> <nop>
 
 " move to next char
 cnoremap <c-b> <space><bs><left>
@@ -98,8 +92,26 @@ cnoremap <esc>* <c-a>
 " open cmdline-window
 cnoremap <c-x><c-e> <c-f>
 
+"~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+" mapping options
+"~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+" escape mappings
+if get(g:, 'readline_esc', 0) || v:version <= 703
+  cnoremap <esc> <nop>
+else
+  " emulate escape unless it was pressed using a modifier
+  function s:esc()
+    if getchar(0)
+      return ""
+    endif
+    return &cpoptions =~ "x" ? "\<cr>" : "\<c-c>"
+  endfunction
+  cnoremap <nowait> <expr> <esc> <sid>esc()
+endif
+
 " meta key mappings
-if get(g:, 'readline_meta', 0) || has('nvim')
+if get(g:, 'readline_meta', has('nvim'))
   cmap <m-b> <esc>b
   cmap <m-B> <esc>B
   cmap <m-f> <esc>f


### PR DESCRIPTION
After the feedback raised in issue #2 I have decided to change the default behavior of escape in the plugin. The old behavior is still available through the `g:readine_esc` option.

When `g:readline_esc` is set to zero (default) the `<Esc>x` mapping will only work if `<Esc>` and `x` is received simultaneously.  This is the case when the user presses ALT-x.  When `<Esc>` is pressed alone it will behave like default and exit the command-line.  When the user presses an invalid mapping like `<M-a>` nothing happens.

When `g:readline_esc` is set to non-zero it will behave as before were `<Esc>` is mapped to `<Nop>`.  This is to avoid closing the command-line by accident when pressing an invalid mapping like `<M-a>`.
